### PR TITLE
202002/downgrade ruby to 2 6 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.7.0-node-browsers
+      - image: circleci/ruby:2.6.5-node-browsers
         environment:
           RAILS_ENV: test
           PGHOST: 127.0.0.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - db/schema.rb
     - node_modules/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6
 
 # ファイル丸ごとブロックに入りそうなファイルは行数制限から外す
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.0'
+ruby '2.6.5'
 
 gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.1.2

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ bin/rails db:seed_fu
 ```
 
 ## 開発環境のバージョン
-- Ruby -v 2.7.0
+- Ruby -v 2.6.5
 - Ruby on Rails -v 6.0.2.1
 
 ## 開発環境のログイン方法


### PR DESCRIPTION
やりたかったこと
---
- Rubyを2.7.0から2.6.5に下げる
- Rails標準のgemから警告が多発したためログがノイズになってしまうのが嫌だった

やったこと
----
- Rubyを2.7.0から2.6.5に下げる
- $ bundle

動作確認方法
---
- [x] `$ bundle exec rubocop` で規約違反がないこと
- [x] `$ bin/rspec` でテストグリーンであること
- [x] `$ rubycritic` でD以下がないこと
