### PR TITLE
Revert "Bump rack from 2.1.2 to 2.2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
-    rack (2.2.0)
+    rack (2.1.2)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
Reverts gotanda-hackathon/knowhow_index#18