### PR TITLE
202002/add admin company rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.rbc
 capybara-*.html
-.rspec
 /public/system
 /coverage/
 /spec/tmp

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
       rubyzip (>= 1.2.2)
     settingslogic (2.0.9)
     sexp_processor (4.14.1)
-    simplecov (0.18.3)
+    simplecov (0.18.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.1)

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -11,6 +11,6 @@
 #
 FactoryBot.define do
   factory :company do
-    name { 'MyString' }
+    sequence(:name) { |n| "テスト企業#{n}" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,8 +29,7 @@ FactoryBot.define do
     password { 'test1234' }
     association :company
 
-    trait :normal_user do
-      administrator { false }
+    trait :not_grader do
       grader { false }
     end
 
@@ -38,9 +37,12 @@ FactoryBot.define do
       grader { true }
     end
 
+    trait :not_administrator do
+      administrator { false }
+    end
+
     trait :administrator do
       administrator { true }
-      grader { true }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,11 +24,23 @@
 #
 FactoryBot.define do
   factory :user do
-    name { 'MyString' }
-    email { 'MyString' }
-    password_digest { 'MyString' }
-    grader { false }
-    administrator { false }
-    company { nil }
+    sequence(:name) { |n| "テストユーザー#{n}" }
+    sequence(:email) { |n| "tester#{n}@example.com" }
+    password { 'test1234' }
+    association :company
+
+    trait :normal_user do
+      administrator { false }
+      grader { false }
+    end
+
+    trait :grader do
+      grader { true }
+    end
+
+    trait :administrator do
+      administrator { true }
+      grader { true }
+    end
   end
 end

--- a/spec/supports/examples/not_accessible_by_normal_user.rb
+++ b/spec/supports/examples/not_accessible_by_normal_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'トップページにリダイレクト' do
+  it 'トップページにリダイレクトされること' do
+    aggregate_failures do
+      expect(page).to have_current_path root_path
+      expect(page).to have_css '.red.lighten-4'
+      expect(page).to have_content '権限がありません'
+    end
+  end
+end

--- a/spec/supports/examples/require_logged_in.rb
+++ b/spec/supports/examples/require_logged_in.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'ログイン画面にリダイレクト' do
+  it 'ログイン画面にリダイレクトすること' do
+    aggregate_failures do
+      expect(page).to have_current_path login_path
+      expect(page).to have_css '.red.lighten-4'
+      expect(page).to have_content 'ログインが必要です'
+    end
+  end
+end

--- a/spec/supports/login_support.rb
+++ b/spec/supports/login_support.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module LoginSupport
+  def sign_in_as(user)
+    visit login_path
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_on 'ログイン'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/system/admin/companies_destroy_spec.rb
+++ b/spec/system/admin/companies_destroy_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '管理画面：企業削除', type: :system do
+  context 'ログインしているとき' do
+    let!(:company) { FactoryBot.create(:company, name: '削除データ') }
+
+    before do
+      sign_in_as(login_user)
+      visit admin_companies_path
+    end
+
+    context '権限が normal_user のとき' do
+      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+
+      it_behaves_like 'トップページにリダイレクト'
+    end
+
+    context '権限が administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :administrator) }
+
+      it '削除ボタンを押すと confirm アラートが出ること' do
+        within "#delete_btn_#{company.id}" do
+          click_on '削除'
+          expect(page.driver.browser.switch_to.alert.text).to eq '本当に削除しますか?'
+          page.driver.browser.switch_to.alert.accept
+        end
+      end
+
+      it '削除ボタンを押すとレコードが削除されていること' do
+        within "#delete_btn_#{company.id}" do
+          click_on '削除'
+          page.driver.browser.switch_to.alert.accept
+        end
+        aggregate_failures do
+          expect(page).to have_current_path admin_companies_path
+          expect(page).to have_css '.green.lighten-4'
+          expect(page).to have_content '削除いたしました'
+          expect(page).not_to have_content company.name
+        end
+      end
+
+      it 'レコードが1件減ること' do
+        expect do
+          within "#delete_btn_#{company.id}" do
+            click_on '削除'
+            page.driver.browser.switch_to.alert.accept
+          end
+          page.find('div', text: '削除いたしました', match: :first)
+        end.to change(Company.all, :count).by(-1)
+      end
+    end
+  end
+
+  context 'ログインしていないとき' do
+    before do
+      visit admin_companies_path
+    end
+
+    it_behaves_like 'ログイン画面にリダイレクト'
+  end
+end

--- a/spec/system/admin/companies_destroy_spec.rb
+++ b/spec/system/admin/companies_destroy_spec.rb
@@ -11,8 +11,8 @@ describe '管理画面：企業削除', type: :system do
       visit admin_companies_path
     end
 
-    context '権限が normal_user のとき' do
-      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+    context '権限が not_administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :not_administrator) }
 
       it_behaves_like 'トップページにリダイレクト'
     end

--- a/spec/system/admin/companies_edit_spec.rb
+++ b/spec/system/admin/companies_edit_spec.rb
@@ -11,8 +11,8 @@ describe '管理画面：企業編集', type: :system do
       visit admin_companies_path
     end
 
-    context '権限が normal_user のとき' do
-      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+    context '権限が not_administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :not_administrator) }
 
       it_behaves_like 'トップページにリダイレクト'
     end

--- a/spec/system/admin/companies_edit_spec.rb
+++ b/spec/system/admin/companies_edit_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '管理画面：企業編集', type: :system do
+  context 'ログインしているとき' do
+    let!(:company) { FactoryBot.create(:company) }
+
+    before do
+      sign_in_as(login_user)
+      visit admin_companies_path
+    end
+
+    context '権限が normal_user のとき' do
+      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+
+      it_behaves_like 'トップページにリダイレクト'
+    end
+
+    context '権限が administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :administrator) }
+
+      context '正しく入力するとき' do
+        before do
+          within "#edit_btn_#{company.id}" do
+            click_on '編集'
+          end
+          page.find('h5', text: '企業編集', match: :first)
+          fill_in '企業名', with: '編集テスト企業'
+          click_on '更新する'
+        end
+
+        it '情報を編集・更新できること' do
+          aggregate_failures do
+            expect(page).to have_current_path edit_admin_company_path(company)
+            expect(page).to have_css '.green.lighten-4'
+            expect(page).to have_content '更新いたしました'
+            expect(page).to have_field '企業名', with: '編集テスト企業'
+          end
+        end
+      end
+
+      context '値を空にするとき' do
+        before do
+          within "#edit_btn_#{company.id}" do
+            click_on '編集'
+          end
+          page.find('h5', text: '企業編集', match: :first)
+          fill_in '企業名', with: ''
+          click_on '更新する'
+        end
+
+        it '情報を更新できずエラーが出ること' do
+          aggregate_failures do
+            expect(page).to have_css '.red.lighten-4'
+            expect(page).to have_content '更新に失敗しました'
+          end
+        end
+      end
+    end
+  end
+
+  context 'ログインしていないとき' do
+    before do
+      visit admin_companies_path
+    end
+
+    it_behaves_like 'ログイン画面にリダイレクト'
+  end
+end

--- a/spec/system/admin/companies_index_spec.rb
+++ b/spec/system/admin/companies_index_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '管理画面：企業一覧', type: :system do
+  context 'ログインしているとき' do
+    let!(:companies) { FactoryBot.create_list(:company, 2) }
+
+    before do
+      sign_in_as(login_user)
+      visit admin_companies_path
+    end
+
+    context '権限が normal_user のとき' do
+      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+
+      it_behaves_like 'トップページにリダイレクト'
+    end
+
+    context '権限が administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :administrator) }
+
+      it '企業の情報が表示されていること' do
+        expect_outline_of(companies[0])
+        expect_outline_of(companies[1])
+      end
+
+      it '編集ボタンが企業の数だけあること' do
+        expect(page).to have_content('編集', count: Company.all.count)
+      end
+
+      it '削除ボタンが企業の数だけあること' do
+        expect(page).to have_content('削除', count: Company.all.count)
+      end
+    end
+  end
+
+  context 'ログインしていないとき' do
+    before do
+      visit admin_companies_path
+    end
+
+    it_behaves_like 'ログイン画面にリダイレクト'
+  end
+
+  def expect_outline_of(company)
+    expect(page).to have_content company.name
+    expect(page).to have_content company.decorate.show_created_at
+  end
+end

--- a/spec/system/admin/companies_index_spec.rb
+++ b/spec/system/admin/companies_index_spec.rb
@@ -11,8 +11,8 @@ describe '管理画面：企業一覧', type: :system do
       visit admin_companies_path
     end
 
-    context '権限が normal_user のとき' do
-      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+    context '権限が not_administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :not_administrator) }
 
       it_behaves_like 'トップページにリダイレクト'
     end

--- a/spec/system/admin/companies_new_spec.rb
+++ b/spec/system/admin/companies_new_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '管理画面：企業作成', type: :system do
+  context 'ログインしているとき' do
+    before do
+      sign_in_as(login_user)
+      visit new_admin_company_path
+    end
+
+    context '権限が normal_user のとき' do
+      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+
+      it_behaves_like 'トップページにリダイレクト'
+    end
+
+    context '権限が administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :administrator) }
+
+      context '正しく入力するとき' do
+        before do
+          fill_in '企業名', with: '新規作成テスト企業'
+          click_on '登録する'
+        end
+
+        it '情報を作成できること' do
+          company = Company.last
+          aggregate_failures do
+            expect(page).to have_current_path admin_companies_path
+            expect(page).to have_css '.green.lighten-4'
+            expect(page).to have_content '登録いたしました'
+            expect(page.all('tbody tr').last).to have_content company.name
+            expect(page.all('tbody tr').last).to have_content company.decorate.show_created_at
+          end
+        end
+      end
+
+      context '何も入力しないとき' do
+        before do
+          click_on '登録する'
+        end
+
+        it '情報を作成できずエラーが出ること' do
+          aggregate_failures do
+            expect(page).to have_css '.red.lighten-4'
+            expect(page).to have_content '登録に失敗しました'
+          end
+        end
+      end
+    end
+  end
+
+  context 'ログインしていないとき' do
+    before do
+      visit new_admin_company_path
+    end
+
+    it_behaves_like 'ログイン画面にリダイレクト'
+  end
+end

--- a/spec/system/admin/companies_new_spec.rb
+++ b/spec/system/admin/companies_new_spec.rb
@@ -9,8 +9,8 @@ describe '管理画面：企業作成', type: :system do
       visit new_admin_company_path
     end
 
-    context '権限が normal_user のとき' do
-      let(:login_user) { FactoryBot.create(:user, :normal_user) }
+    context '権限が not_administrator のとき' do
+      let(:login_user) { FactoryBot.create(:user, :not_administrator) }
 
       it_behaves_like 'トップページにリダイレクト'
     end


### PR DESCRIPTION
やりたかったこと
---
- 企業CRUDのSystemSpec記載 https://github.com/gotanda-hackathon/knowhow_index/issues/34

やったこと
----
- factorybotのデータをセット
- spec/support ディレクトリの拡張
- rspecの出力形式を変更
- 企業CRUDのSystemSpec記載

動作確認方法
---
- [x] `$ bundle exec rubocop` で規約違反がないこと
- [x] `$ bin/rspec` でテストグリーンであること
- [x] `$ rubycritic` でD以下がないこと